### PR TITLE
Rename reviewed/ok-to-test to ok-to-test

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
   ],
   labels: [
     'kind/enhancement',
-    'reviewed/ok-to-test',
+    'ok-to-test',
   ],
   postUpdateOptions: [
     'gomodTidy',


### PR DESCRIPTION
**What this PR does / why we need it**:
/kind cleanup
With this PR one should use the label `ok-to-test` to allow testing to be started when PRs are opened by external contributors.
Related to https://github.com/gardener/cc-utils/pull/1512

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
